### PR TITLE
Add multi-profile support

### DIFF
--- a/Sources/HermesDesktop/App/AppState.swift
+++ b/Sources/HermesDesktop/App/AppState.swift
@@ -39,6 +39,8 @@ final class AppState: ObservableObject {
     @Published var soulDocument = FileEditorDocument(trackedFile: .soul)
     @Published var pendingSectionSelection: AppSection?
     @Published var showDiscardChangesAlert = false
+    @Published var availableProfiles: [HermesAgentProfile] = []
+    @Published var activeProfile: HermesAgentProfile = .defaultProfile
 
     let connectionStore: ConnectionStore
     let sshTransport: SSHTransport
@@ -52,6 +54,7 @@ final class AppState: ObservableObject {
     private let sessionPageSize = 50
     private var sessionOffset = 0
     private var statusTask: Task<Void, Never>?
+    private var profileSwitchTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -150,6 +153,30 @@ final class AppState: ObservableObject {
         }
     }
 
+    func selectProfile(_ profile: HermesAgentProfile) {
+        profileSwitchTask?.cancel()
+        profileSwitchTask = Task {
+            guard !Task.isCancelled else { return }
+
+            if var cp = activeConnection {
+                cp.lastUsedProfileID = profile.id
+                connectionStore.upsert(cp)
+            }
+
+            let previousProfiles = availableProfiles
+            resetWorkspaceStateForConnectionChange()
+            availableProfiles = previousProfiles
+            activeProfile = profile
+
+            guard !Task.isCancelled else { return }
+            await refreshOverview()
+
+            guard overviewError == nil, !Task.isCancelled else { return }
+            await ensureInitialFileLoads()
+            await loadSessions(reset: true)
+        }
+    }
+
     func testConnection(_ profile: ConnectionProfile) {
         Task {
             do {
@@ -208,7 +235,7 @@ final class AppState: ObservableObject {
         do {
             isBusy = true
             overviewError = nil
-            overview = try await remoteHermesService.discover(connection: profile)
+            overview = try await remoteHermesService.discover(connection: profile, hermesHome: activeProfile.hermesHome)
             isBusy = false
             if manual {
                 isRefreshingOverview = false
@@ -246,7 +273,7 @@ final class AppState: ObservableObject {
     }
 
     func loadTrackedFile(_ trackedFile: RemoteTrackedFile, forceReload: Bool = false) async {
-        guard let profile = activeConnection else { return }
+        guard let profile = activeConnection, let discovery = overview else { return }
         var document = document(for: trackedFile)
 
         if document.hasLoaded && !forceReload {
@@ -258,7 +285,7 @@ final class AppState: ObservableObject {
         setDocument(document)
 
         do {
-            let snapshot = try await fileEditorService.read(file: trackedFile, connection: profile)
+            let snapshot = try await fileEditorService.read(file: trackedFile, discovery: discovery, connection: profile)
             document.content = snapshot.content
             document.originalContent = snapshot.content
             document.remoteContentHash = snapshot.contentHash
@@ -275,7 +302,7 @@ final class AppState: ObservableObject {
     }
 
     func saveTrackedFile(_ trackedFile: RemoteTrackedFile) async {
-        guard let profile = activeConnection else { return }
+        guard let profile = activeConnection, let discovery = overview else { return }
         var document = document(for: trackedFile)
         document.isLoading = true
         document.errorMessage = nil
@@ -286,6 +313,7 @@ final class AppState: ObservableObject {
                 file: trackedFile,
                 content: document.content,
                 expectedContentHash: document.remoteContentHash,
+                discovery: discovery,
                 connection: profile
             )
             document.originalContent = document.content
@@ -328,7 +356,8 @@ final class AppState: ObservableObject {
                 connection: profile,
                 offset: reset ? 0 : sessionOffset,
                 limit: sessionPageSize,
-                query: normalizedQuery
+                query: normalizedQuery,
+                hintedSessionStore: overview?.sessionStore
             )
 
             if reset {
@@ -559,7 +588,22 @@ final class AppState: ObservableObject {
     }
 
     private func prepareWorkspaceForActiveConnection() async {
-        guard activeConnection != nil else { return }
+        guard let connection = activeConnection else { return }
+
+        do {
+            let discovered = try await remoteHermesService.discoverProfiles(connection: connection)
+            availableProfiles = discovered
+            if let lastID = connection.lastUsedProfileID,
+               let match = discovered.first(where: { $0.id == lastID }) {
+                activeProfile = match
+            } else {
+                activeProfile = discovered.first(where: { $0.id == "" }) ?? .defaultProfile
+            }
+        } catch {
+            availableProfiles = [.defaultProfile]
+            activeProfile = .defaultProfile
+        }
+
         await refreshOverview()
 
         guard overviewError == nil else {
@@ -592,6 +636,8 @@ final class AppState: ObservableObject {
         overview = nil
         overviewError = nil
         isRefreshingOverview = false
+        availableProfiles = []
+        activeProfile = .defaultProfile
         sessions = []
         sessionMessages = []
         sessionsError = nil

--- a/Sources/HermesDesktop/Models/ConnectionProfile.swift
+++ b/Sources/HermesDesktop/Models/ConnectionProfile.swift
@@ -7,6 +7,7 @@ struct ConnectionProfile: Codable, Identifiable, Equatable, Hashable {
     var sshHost: String
     var sshPort: Int?
     var sshUser: String
+    var lastUsedProfileID: String?
     var createdAt: Date
     var updatedAt: Date
     var lastConnectedAt: Date?
@@ -18,6 +19,7 @@ struct ConnectionProfile: Codable, Identifiable, Equatable, Hashable {
         sshHost: String = "",
         sshPort: Int? = nil,
         sshUser: String = "",
+        lastUsedProfileID: String? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         lastConnectedAt: Date? = nil
@@ -28,6 +30,7 @@ struct ConnectionProfile: Codable, Identifiable, Equatable, Hashable {
         self.sshHost = sshHost
         self.sshPort = sshPort
         self.sshUser = sshUser
+        self.lastUsedProfileID = lastUsedProfileID
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.lastConnectedAt = lastConnectedAt

--- a/Sources/HermesDesktop/Models/HermesAgentProfile.swift
+++ b/Sources/HermesDesktop/Models/HermesAgentProfile.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct HermesAgentProfile: Identifiable, Codable, Hashable, Equatable {
+    let id: String
+    let hermesHome: String
+
+    var displayName: String { id.isEmpty ? "Default" : id }
+    var isDefault: Bool { id.isEmpty }
+
+    static let defaultProfile = HermesAgentProfile(id: "", hermesHome: "~/.hermes")
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case hermesHome
+    }
+}

--- a/Sources/HermesDesktop/Services/FileEditorService.swift
+++ b/Sources/HermesDesktop/Services/FileEditorService.swift
@@ -7,9 +7,9 @@ final class FileEditorService: @unchecked Sendable {
         self.sshTransport = sshTransport
     }
 
-    func read(file: RemoteTrackedFile, connection: ConnectionProfile) async throws -> FileSnapshot {
+    func read(file: RemoteTrackedFile, discovery: RemoteDiscovery, connection: ConnectionProfile) async throws -> FileSnapshot {
         let script = try RemotePythonScript.wrap(
-            FileRequest(path: file.remoteTildePath),
+            FileRequest(path: resolvePath(for: file, in: discovery)),
             body: """
             import hashlib
             import json
@@ -64,11 +64,12 @@ final class FileEditorService: @unchecked Sendable {
         file: RemoteTrackedFile,
         content: String,
         expectedContentHash: String?,
+        discovery: RemoteDiscovery,
         connection: ConnectionProfile
     ) async throws -> FileSaveResult {
         let script = try RemotePythonScript.wrap(
             FileWriteRequest(
-                path: file.remoteTildePath,
+                path: resolvePath(for: file, in: discovery),
                 content: content,
                 expectedContentHash: expectedContentHash,
                 atomic: true
@@ -154,6 +155,14 @@ final class FileEditorService: @unchecked Sendable {
             path: response.path,
             contentHash: response.contentHash
         )
+    }
+
+    private func resolvePath(for file: RemoteTrackedFile, in discovery: RemoteDiscovery) -> String {
+        switch file {
+        case .user:   return discovery.paths.user
+        case .memory: return discovery.paths.memory
+        case .soul:   return discovery.paths.soul
+        }
     }
 }
 

--- a/Sources/HermesDesktop/Services/RemoteHermesService.swift
+++ b/Sources/HermesDesktop/Services/RemoteHermesService.swift
@@ -7,15 +7,28 @@ final class RemoteHermesService: @unchecked Sendable {
         self.sshTransport = sshTransport
     }
 
-    func discover(connection: ConnectionProfile) async throws -> RemoteDiscovery {
-        try await sshTransport.executeJSON(
+    func discover(connection: ConnectionProfile, hermesHome: String = "~/.hermes") async throws -> RemoteDiscovery {
+        let script = try RemotePythonScript.wrap(
+            HermesDiscoveryRequest(hermesHome: hermesHome),
+            body: discoveryBody
+        )
+        return try await sshTransport.executeJSON(
             on: connection,
-            pythonScript: discoveryScript,
+            pythonScript: script,
             responseType: RemoteDiscovery.self
         )
     }
 
-    private var discoveryScript: String {
+    func discoverProfiles(connection: ConnectionProfile) async throws -> [HermesAgentProfile] {
+        let response = try await sshTransport.executeJSON(
+            on: connection,
+            pythonScript: profilesScript,
+            responseType: ProfilesResponse.self
+        )
+        return response.profiles
+    }
+
+    private var discoveryBody: String {
         """
         import json
         import pathlib
@@ -129,7 +142,7 @@ final class RemoteHermesService: @unchecked Sendable {
 
         try:
             home = pathlib.Path.home()
-            hermes_home = home / ".hermes"
+            hermes_home = pathlib.Path(payload["hermes_home"]).expanduser()
             user_path = hermes_home / "memories" / "USER.md"
             memory_path = hermes_home / "memories" / "MEMORY.md"
             soul_path = hermes_home / "SOUL.md"
@@ -159,4 +172,35 @@ final class RemoteHermesService: @unchecked Sendable {
             fail(f"Unable to discover the remote Hermes workspace: {exc}")
         """
     }
+
+    private var profilesScript: String {
+        """
+        import json
+        import pathlib
+
+        home = pathlib.Path.home()
+        hermes_root = home / ".hermes"
+        profiles_dir = hermes_root / "profiles"
+
+        profiles = [{"id": "", "hermesHome": str(hermes_root)}]
+
+        if profiles_dir.exists() and profiles_dir.is_dir():
+            for entry in sorted(profiles_dir.iterdir()):
+                if entry.is_dir():
+                    profiles.append({"id": entry.name, "hermesHome": str(entry)})
+
+        print(json.dumps({"profiles": profiles}, ensure_ascii=False))
+        """
+    }
+}
+
+private struct HermesDiscoveryRequest: Encodable {
+    let hermesHome: String
+    enum CodingKeys: String, CodingKey {
+        case hermesHome = "hermes_home"
+    }
+}
+
+private struct ProfilesResponse: Decodable {
+    let profiles: [HermesAgentProfile]
 }

--- a/Sources/HermesDesktop/Services/SessionBrowserService.swift
+++ b/Sources/HermesDesktop/Services/SessionBrowserService.swift
@@ -11,10 +11,18 @@ final class SessionBrowserService: @unchecked Sendable {
         connection: ConnectionProfile,
         offset: Int,
         limit: Int,
-        query: String
+        query: String,
+        hintedSessionStore: RemoteSessionStore? = nil
     ) async throws -> SessionListPage {
         let script = try RemotePythonScript.wrap(
-            SessionPageRequest(offset: offset, limit: limit, query: query),
+            SessionPageRequest(
+                offset: offset,
+                limit: limit,
+                query: query,
+                hintedStorePath: hintedSessionStore?.path,
+                hintedSessionTable: hintedSessionStore?.sessionTable,
+                hintedMessageTable: hintedSessionStore?.messageTable
+            ),
             body: sessionListBody
         )
 
@@ -72,7 +80,11 @@ final class SessionBrowserService: @unchecked Sendable {
         context = None
 
         try:
-            context = try_open_store()
+            context = try_open_store(
+                request.get("hinted_store_path"),
+                request.get("hinted_session_table"),
+                request.get("hinted_message_table")
+            )
 
             if context is None:
                 items = build_jsonl_session_summaries()
@@ -809,6 +821,18 @@ private struct SessionPageRequest: Encodable {
     let offset: Int
     let limit: Int
     let query: String
+    let hintedStorePath: String?
+    let hintedSessionTable: String?
+    let hintedMessageTable: String?
+
+    enum CodingKeys: String, CodingKey {
+        case offset
+        case limit
+        case query
+        case hintedStorePath = "hinted_store_path"
+        case hintedSessionTable = "hinted_session_table"
+        case hintedMessageTable = "hinted_message_table"
+    }
 }
 
 private struct SessionDetailRequest: Encodable {

--- a/Sources/HermesDesktop/Views/RootView.swift
+++ b/Sources/HermesDesktop/Views/RootView.swift
@@ -23,6 +23,18 @@ struct RootView: View {
                     }
                 }
 
+                if appState.availableProfiles.count > 1 {
+                    Section("Profile") {
+                        Picker("Profile", selection: profileBinding) {
+                            ForEach(appState.availableProfiles) { profile in
+                                Text(profile.displayName).tag(profile)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                    }
+                }
+
                 Section("Workspace") {
                     ForEach(availableSections) { section in
                         Label(section.title, systemImage: section.systemImage)
@@ -80,6 +92,13 @@ struct RootView: View {
             guard let newValue else { return }
             appState.requestSectionSelection(newValue)
         }
+    }
+
+    private var profileBinding: Binding<HermesAgentProfile> {
+        Binding(
+            get: { appState.activeProfile },
+            set: { appState.selectProfile($0) }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Adds support for Hermes Agent named profiles at `~/.hermes/profiles/<name>/` alongside the default `~/.hermes/` workspace
- Profile picker appears in the sidebar (between Active Connection and Workspace) only when multiple profiles exist — single-profile setups are completely unaffected
- Last-used profile is persisted per connection and auto-selected on reconnect

## Changes

| File | Change |
|---|---|
| `Models/HermesAgentProfile.swift` | New model — `id`, `hermesHome`, `displayName`, `defaultProfile` |
| `Models/ConnectionProfile.swift` | Added `lastUsedProfileID: String?` (backward-compatible) |
| `Services/RemoteHermesService.swift` | `discover(connection:hermesHome:)` parameterized; new `discoverProfiles()` enumerates `~/.hermes/profiles/*/` via SSH Python |
| `Services/FileEditorService.swift` | `read`/`write` accept `discovery: RemoteDiscovery`; paths resolved from discovery instead of hardcoded tilde paths |
| `Services/SessionBrowserService.swift` | `listSessions` gains `hintedSessionStore` to scope sessions to active profile |
| `App/AppState.swift` | Profile discovery on connect; `selectProfile()` with task cancellation; all service calls updated |
| `Views/RootView.swift` | Conditional `Section("Profile")` with `.menu` Picker |

## Testing

To test profile switching, create a named profile on the remote host:
```bash
mkdir -p ~/.hermes/profiles/work/memories
cp ~/.hermes/memories/USER.md ~/.hermes/profiles/work/memories/
cp ~/.hermes/SOUL.md ~/.hermes/profiles/work/
cp ~/.hermes/state.db ~/.hermes/profiles/work/
```
Then reconnect — the Profile picker will appear in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)