### PR TITLE
Stamp Info.plist version from tags at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,12 @@ To create the GitHub Releases archive:
 Release artifact:
 
 - `dist/HermesDesktop.app.zip` as a universal macOS archive for Apple Silicon and Intel Macs
+
+The bundled `Info.plist` is stamped at build time so the app's `CFBundleShortVersionString`
+and `CFBundleVersion` match the release being built:
+
+- if `HERMES_VERSION` is set (e.g. `HERMES_VERSION=0.2.0 ./scripts/package-github-release.sh`), it wins
+- otherwise, if `HEAD` is on an annotated tag like `v0.2.0`, the leading `v` is stripped and `0.2.0` is stamped
+- otherwise the template version in `packaging/Info.plist` is left as-is (useful for local dev builds)
+
+`CFBundleVersion` follows the same order, falling back to the commit count (`git rev-list --count HEAD`) so every build is monotonically numbered. `HERMES_BUILD` overrides it.

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -64,6 +64,39 @@ pick_sdk() {
     printf '%s\n' "$selected"
 }
 
+derive_version() {
+    if [[ -n "${HERMES_VERSION:-}" ]]; then
+        printf '%s\n' "$HERMES_VERSION"
+        return
+    fi
+    local tag
+    tag="$(git -C "$ROOT_DIR" describe --tags --exact-match 2>/dev/null || true)"
+    printf '%s\n' "${tag#v}"
+}
+
+derive_build_number() {
+    if [[ -n "${HERMES_BUILD:-}" ]]; then
+        printf '%s\n' "$HERMES_BUILD"
+        return
+    fi
+    git -C "$ROOT_DIR" rev-list --count HEAD 2>/dev/null || true
+}
+
+stamp_plist_versions() {
+    local plist="$1"
+    local version build
+    version="$(derive_version)"
+    build="$(derive_build_number)"
+    if [[ -n "$version" ]]; then
+        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$plist"
+    fi
+    if [[ -n "$build" ]]; then
+        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build" "$plist"
+    fi
+    STAMPED_VERSION="${version:-$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$plist")}"
+    STAMPED_BUILD="${build:-$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$plist")}"
+}
+
 generate_icon() {
     mkdir -p "$ICONSET_PATH"
 
@@ -151,6 +184,7 @@ fi
 
 cp "$UNIVERSAL_EXECUTABLE_PATH" "$MACOS_PATH/$APP_NAME"
 cp "$PLIST_PATH" "$CONTENTS_PATH/Info.plist"
+stamp_plist_versions "$CONTENTS_PATH/Info.plist"
 cp "$ICNS_PATH" "$RESOURCES_PATH/AppIcon.icns"
 cp "$SHADER_SOURCE_PATH" "$RESOURCES_PATH/Shaders.metal"
 codesign --force --deep --sign - "$BUNDLE_PATH" >/dev/null
@@ -159,5 +193,6 @@ codesign --verify --deep --strict "$BUNDLE_PATH" >/dev/null
 echo
 echo "App bundle created:"
 echo "  $BUNDLE_PATH"
+echo "Version: ${STAMPED_VERSION} (build ${STAMPED_BUILD})"
 echo "Architectures: $(lipo -archs "$MACOS_PATH/$APP_NAME")"
 echo "Ad-hoc signed bundle created: macOS may still require right-click > Open on first launch."


### PR DESCRIPTION
## Summary

- The packaged `Info.plist` currently ships a static `0.1.0` / `1` for `CFBundleShortVersionString` / `CFBundleVersion`, which can drift from the tag the release archive is built against.
- `scripts/build-macos-app.sh` now stamps both fields into the bundled plist during assembly (before `codesign`), with precedence:
  1. `HERMES_VERSION` / `HERMES_BUILD` env vars win (e.g. `HERMES_VERSION=0.2.0 ./scripts/package-github-release.sh`)
  2. else, if `HEAD` is on an annotated tag like `v0.2.0`, the leading `v` is stripped and `0.2.0` is stamped; `CFBundleVersion` falls back to `git rev-list --count HEAD` so every build is monotonically numbered
  3. else the template values in `packaging/Info.plist` are left untouched (useful for local dev builds without reachable tags)
- `git describe --exact-match` is used (not `--abbrev=0`) so dev commits between tags don't falsely claim the prior tag's version.
- The completion output now echoes the stamped version and build number.

README gets a short paragraph under the release-archive section documenting the env overrides and the tag-based fallback.

## Test plan

- [x] Clean build with no tags, no env → short version falls back to template `0.1.0`, build becomes commit count (verified `32`)
- [x] `HERMES_VERSION=0.2.0 HERMES_BUILD=42 ./scripts/build-macos-app.sh` → plist contains `0.2.0` / `42`
- [x] Temporary local tag `v0.1.0-test` on `HEAD` → plist contains `0.1.0-test` (leading `v` stripped)
- [x] `codesign --verify --deep --strict` succeeds after stamping in all three cases (bundle signature covers the final plist since stamping runs before `codesign`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)