### PR TITLE
Add support for additional methods of loading ssh agents (here gentoo's keychain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /AGENTS.md
 /.build
+/.build-tests
 /dist
 /docs/
 /private/

--- a/Sources/HermesDesktop/Services/SSH/SSHTransport.swift
+++ b/Sources/HermesDesktop/Services/SSH/SSHTransport.swift
@@ -1,7 +1,10 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "net.allmytech.HermesDesktop", category: "SSHTransport")
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "HermesDesktop",
+    category: "SSHTransport"
+)
 
 struct SSHCommandResult {
     let stdout: String

--- a/Sources/HermesDesktop/Services/SSH/SSHTransport.swift
+++ b/Sources/HermesDesktop/Services/SSH/SSHTransport.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "net.allmytech.HermesDesktop", category: "SSHTransport")
 
 struct SSHCommandResult {
     let stdout: String
@@ -27,6 +30,7 @@ enum SSHTransportError: LocalizedError {
 
 final class SSHTransport: @unchecked Sendable {
     private let paths: AppPaths
+    private let resolvedEnvironment: [String: String]
 
     private enum ConnectionPurpose {
         case service
@@ -35,6 +39,72 @@ final class SSHTransport: @unchecked Sendable {
 
     init(paths: AppPaths) {
         self.paths = paths
+        self.resolvedEnvironment = SSHTransport.buildResolvedEnvironment()
+    }
+
+    // Environment forwarded to terminal SSH subprocesses (SwiftTerm key=value format).
+    var terminalEnvironment: [String] {
+        var vars = ["TERM=xterm-256color", "COLORTERM=truecolor"]
+        for key in ["HOME", "USER", "SSH_AUTH_SOCK", "SSH_AGENT_PID", "PATH"] {
+            if let value = resolvedEnvironment[key] {
+                vars.append("\(key)=\(value)")
+            }
+        }
+        return vars
+    }
+
+    private static func buildResolvedEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        // Always prefer the keychain file: the process environment is frozen at launch and
+        // may point to a stale agent socket from a previous session.
+        if let sock = keychainAuthSock() {
+            logger.info("SSH_AUTH_SOCK from keychain file: \(sock, privacy: .public)")
+            env["SSH_AUTH_SOCK"] = sock
+        } else if let sock = env["SSH_AUTH_SOCK"] {
+            logger.info("SSH_AUTH_SOCK from process environment: \(sock, privacy: .public)")
+        } else {
+            logger.warning("SSH_AUTH_SOCK not found in keychain files or environment — SSH agent auth will not work")
+        }
+        return env
+    }
+
+    // Reads SSH_AUTH_SOCK from funtoo/keychain shell files in ~/.keychain/.
+    // Scans all *-sh files so hostname variations (short vs FQDN) don't matter.
+    private static func keychainAuthSock() -> String? {
+        let keychainDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".keychain")
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: keychainDir, includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else {
+            logger.debug("~/.keychain directory not found or unreadable")
+            return nil
+        }
+        let shFiles = entries
+            .filter { $0.lastPathComponent.hasSuffix("-sh") }
+            .sorted {
+                let d1 = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                let d2 = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                return d1 > d2
+            }
+        for file in shFiles {
+            guard let content = try? String(contentsOf: file, encoding: .utf8) else {
+                logger.debug("Could not read keychain file: \(file.lastPathComponent)")
+                continue
+            }
+            for line in content.components(separatedBy: .newlines) {
+                guard line.hasPrefix("SSH_AUTH_SOCK=") else { continue }
+                var value = String(line.dropFirst("SSH_AUTH_SOCK=".count))
+                    .components(separatedBy: ";").first?
+                    .trimmingCharacters(in: .whitespaces) ?? ""
+                // Strip surrounding quotes written by keychain: SSH_AUTH_SOCK="/path/..."
+                if value.hasPrefix("\"") && value.hasSuffix("\"") && value.count >= 2 {
+                    value = String(value.dropFirst().dropLast())
+                }
+                if !value.isEmpty { return value }
+            }
+            logger.debug("No SSH_AUTH_SOCK found in keychain file: \(file.lastPathComponent)")
+        }
+        return nil
     }
 
     func execute(
@@ -181,6 +251,7 @@ final class SSHTransport: @unchecked Sendable {
 
             process.executableURL = executableURL
             process.arguments = arguments
+            process.environment = resolvedEnvironment
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
@@ -218,6 +289,12 @@ final class SSHTransport: @unchecked Sendable {
                     remainingStderr: remainingStderr
                 )
 
+                if process.terminationStatus != 0 {
+                    logger.error("ssh exited \(process.terminationStatus, privacy: .public): \(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines), privacy: .public)")
+                } else {
+                    logger.debug("ssh exited 0")
+                }
+
                 guard state.claimResume() else { return }
                 continuation.resume(returning: result)
             }
@@ -225,7 +302,7 @@ final class SSHTransport: @unchecked Sendable {
             do {
                 try process.run()
                 if let standardInput,
-                   let pipe = process.standardInput as? Pipe {
+                    let pipe = process.standardInput as? Pipe {
                     pipe.fileHandleForWriting.write(standardInput)
                     do {
                         try pipe.fileHandleForWriting.close()

--- a/Sources/HermesDesktop/Services/Terminal/TerminalSession.swift
+++ b/Sources/HermesDesktop/Services/Terminal/TerminalSession.swift
@@ -4,6 +4,7 @@ import Foundation
 final class TerminalSession: ObservableObject, @unchecked Sendable {
     let connection: ConnectionProfile
     let sshArguments: [String]
+    let terminalEnvironment: [String]
     private let viewHost = TerminalViewHost()
 
     @Published var terminalTitle: String
@@ -16,6 +17,7 @@ final class TerminalSession: ObservableObject, @unchecked Sendable {
     init(connection: ConnectionProfile, sshTransport: SSHTransport) {
         self.connection = connection
         self.sshArguments = sshTransport.shellArguments(for: connection)
+        self.terminalEnvironment = sshTransport.terminalEnvironment
         self.terminalTitle = "\(connection.label) · \(connection.resolvedHermesProfileName)"
         viewHost.setEventHandlers(
             onProcessStart: { [weak self] in
@@ -64,7 +66,8 @@ final class TerminalSession: ObservableObject, @unchecked Sendable {
             in: container,
             request: TerminalLaunchRequest(
                 sshArguments: sshArguments,
-                launchToken: launchToken
+                launchToken: launchToken,
+                terminalEnvironment: terminalEnvironment
             ),
             appearance: appearance,
             isActive: isActive

--- a/Sources/HermesDesktop/Services/Terminal/TerminalViewHost.swift
+++ b/Sources/HermesDesktop/Services/Terminal/TerminalViewHost.swift
@@ -86,15 +86,10 @@ final class TerminalViewHost: NSObject, LocalProcessTerminalViewDelegate {
         guard startedLaunchToken != request.launchToken else { return }
         startedLaunchToken = request.launchToken
 
-        let environment = [
-            "TERM=xterm-256color",
-            "COLORTERM=truecolor"
-        ]
-
         hostView.terminalView.startProcess(
             executable: "/usr/bin/ssh",
             args: request.sshArguments,
-            environment: environment,
+            environment: request.terminalEnvironment,
             execName: "ssh"
         )
         onProcessStart?()
@@ -125,6 +120,7 @@ final class TerminalViewHost: NSObject, LocalProcessTerminalViewDelegate {
 struct TerminalLaunchRequest {
     let sshArguments: [String]
     let launchToken: UUID
+    let terminalEnvironment: [String]
 }
 
 final class TerminalMountContainerView: NSView {


### PR DESCRIPTION
I am using `keychain` (https://wiki.gentoo.org/wiki/Keychain/en) as part of my `oh-my-zsh` configuration to load my SSH key (and automatically start the agent).
In the current version, the Desktop application was unable to find the environment variable (I encountered SSH errors when trying to connect, whereas the terminal connected without issue).

As such, I worked on the following PR to propagate the resolved SSH environment coming from terminal sessions.

This PR enhances SSH terminal launches so they inherit the same resolved environment as other SSH subprocesses, with a focus on reliable agent forwarding.

It adds environment resolution to `SSHTransport`, including:
- loading `SSH_AUTH_SOCK` from `~/.keychain/*-sh` when available (falling back to the app process environment)
- forwarding key shell vars (`SSH_AUTH_SOCK`, `SSH_AGENT_PID`, ...)
- adding structured logging around SSH environment resolution and non-zero SSH exits (I needed this to figure out why it was not working despite a few attempts) [The app process environment can be stale after launch, especially for SSH_AUTH_SOCK. Resolving it from keychain files at runtime makes terminal SSH sessions more likely to find the active SSH agent and authenticate correctly]


It also threads that resolved environment through terminal startup by:
- storing the terminal launch environment on `TerminalSession`
- passing it via `TerminalLaunchRequest`
- using it in `TerminalViewHost` instead of the previous minimal fixed environment

Testing:
- rebuilt local application using `./scripts/build-macos-app.sh` and confirmed I was able to run the Desktop application and connect to my ssh alias
- ran `./scripts/run-tests.sh` with a result of `Test run with 9 tests in 3 suites passed after 0.011 seconds.`
- note: not tested without `keychain` use.