### PR TITLE
fix: recreate SSH control socket directory before use

### DIFF
--- a/Sources/HermesDesktop/Services/Storage/AppPaths.swift
+++ b/Sources/HermesDesktop/Services/Storage/AppPaths.swift
@@ -30,9 +30,14 @@ struct AppPaths {
     }
 
     func controlPath(for connection: ConnectionProfile) -> String {
-        controlSocketDirectoryURL
+        ensureControlSocketDirectoryExists()
+        return controlSocketDirectoryURL
             .appendingPathComponent(controlSocketIdentifier(for: connection))
             .path
+    }
+
+    private func ensureControlSocketDirectoryExists() {
+        createIfNeeded(at: controlSocketDirectoryURL)
     }
 
     private func createIfNeeded(at url: URL) {

--- a/Tests/HermesDesktopTests/ConnectionProfileTests.swift
+++ b/Tests/HermesDesktopTests/ConnectionProfileTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import HermesDesktop
 
@@ -65,5 +66,25 @@ struct ConnectionProfileTests {
             profile.remoteShellBootstrapCommand ==
                 "export HERMES_HOME=\"$HOME/.hermes/profiles/research\\\"lab\"; exec \"${SHELL:-/bin/zsh}\" -l"
         )
+    }
+
+    @Test
+    func controlPathRecreatesTemporarySocketDirectoryWhenPruned() throws {
+        let fileManager = FileManager.default
+        let paths = AppPaths(fileManager: fileManager)
+        try? fileManager.removeItem(at: paths.controlSocketDirectoryURL)
+
+        let profile = ConnectionProfile(
+            label: "Hermes VM",
+            sshAlias: "hermes",
+            sshUser: "ubuntu"
+        ).updated()
+
+        let controlPath = paths.controlPath(for: profile)
+
+        var isDirectory: ObjCBool = false
+        #expect(fileManager.fileExists(atPath: paths.controlSocketDirectoryURL.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+        #expect(controlPath.hasPrefix(paths.controlSocketDirectoryURL.path))
     }
 }


### PR DESCRIPTION
## Summary
- Recreate the temporary SSH control socket directory immediately before returning a service `ControlPath`.
- Prevent Overview discovery from failing after `/tmp/hermes-desktop-control` is pruned while the app stays open.
- Add a regression test that removes the control socket directory before requesting a control path.

## Test Plan
- [x] `PATH="$HOME/.swiftly/bin:$PATH" ./scripts/run-tests.sh`

## Notes
Observed failure:

`unix_listener: cannot bind to path /tmp/hermes-desktop-control/<hash>.<random>: No such file or directory`

This happens when SSH tries to create the multiplexing socket but the parent directory no longer exists.
