### PR TITLE
Fix kanban load failing against WAL DB without active sidecars

### DIFF
--- a/Sources/HermesDesktop/Services/KanbanBrowserService.swift
+++ b/Sources/HermesDesktop/Services/KanbanBrowserService.swift
@@ -952,7 +952,7 @@ final class KanbanBrowserService: @unchecked Sendable {
                     except Exception:
                         stats = direct_stats(conn)
                 else:
-                    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                    conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
                     conn.row_factory = sqlite3.Row
                     tasks = direct_tasks(conn, include_archived)
                     assignees = direct_assignees(conn)
@@ -1036,7 +1036,7 @@ final class KanbanBrowserService: @unchecked Sendable {
                         "worker_log": worker_log,
                     }
 
-                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
                 conn.row_factory = sqlite3.Row
                 if not table_exists(conn, "tasks"):
                     return None

--- a/Sources/HermesDesktop/Services/RemoteHermesService.swift
+++ b/Sources/HermesDesktop/Services/RemoteHermesService.swift
@@ -37,7 +37,7 @@ final class RemoteHermesService: @unchecked Sendable {
 
             for candidate in iter_session_store_candidates(hermes_home):
                 try:
-                    conn = sqlite3.connect(f"file:{candidate}?mode=ro", uri=True)
+                    conn = sqlite3.connect(f"file:{candidate}?mode=ro&immutable=1", uri=True)
                     cursor = conn.execute(
                         "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
                     )


### PR DESCRIPTION
Fixes #20.

## What

`sqlite3.connect(f"file:{db}?mode=ro", uri=True)` refuses to open WAL-mode
databases that lack `-shm`/`-wal` sidecars on disk — the common state when no
Hermes process is currently holding the DB open. Adding `&immutable=1` makes
SQLite skip the WAL setup entirely so the read-only open succeeds regardless
of sidecar state.

## Diff

```diff
- conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+ conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
```

Three sites:
- `Sources/HermesDesktop/Services/KanbanBrowserService.swift` — load_board fallback
- `Sources/HermesDesktop/Services/KanbanBrowserService.swift` — kanban detail/comments read
- `Sources/HermesDesktop/Services/RemoteHermesService.swift` — session_store discovery

The `kb.connect()` branch in `load_board` (when `hermes_cli.kanban_db` is
importable) is untouched and unaffected — it opens through hermes_cli's
standard connect path, which already works against WAL DBs without sidecars.

## Verification

Reproduced + verified against the broken state on a real Hermes Agent v0.12.0
host with `~/.hermes/kanban.db` in default WAL mode and no Hermes process
holding it:

```
OLD (mode=ro)             FAIL: unable to open database file
NEW (mode=ro&immutable=1) OK, tasks: 0
```

In the desktop app: Kanban tab now loads (empty board) instead of showing
the error toast.

## Trade-off

`immutable=1` tells SQLite the file won't change while the connection is
open, so a strictly consistent snapshot isn't guaranteed if a writer mutates
the DB during a read. For one-shot SELECT-only loads (which is what these
sites do) that's an acceptable trade-off vs. the current hard error. If a
stronger guarantee is wanted later, the cleanest follow-up would be to drop
the URI form entirely and call `sqlite3.connect(str(db_path))` like the
`kb.connect()` path does.

See #20 for the full diagnosis, repro recipe, and a `~/.zshenv`-based
workaround for affected users on the current release.