### PR TITLE
Wrap remote bootstrap in exec /bin/sh -c for fish shell compatibility

### DIFF
--- a/Sources/HermesDesktop/Models/ConnectionProfile.swift
+++ b/Sources/HermesDesktop/Models/ConnectionProfile.swift
@@ -115,13 +115,22 @@ struct ConnectionProfile: Codable, Identifiable, Equatable, Hashable {
         }
 
         let exportCommand = "export HERMES_HOME=\"\(shellHomeExpression)\""
-        guard let startupCommandLine,
-              !startupCommandLine.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return "\(exportCommand); exec \"${SHELL:-/bin/zsh}\" -l"
+
+        let innerCommand: String
+        if let startupCommandLine,
+              !startupCommandLine.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let escapedStartupCommand = startupCommandLine.escapedForDoubleQuotedShellArgument
+            innerCommand = "\(exportCommand); exec \"${SHELL:-/bin/zsh}\" -lc \"\(escapedStartupCommand)\""
+        } else {
+            innerCommand = "\(exportCommand); exec \"${SHELL:-/bin/zsh}\" -l"
         }
 
-        let escapedStartupCommand = startupCommandLine.escapedForDoubleQuotedShellArgument
-        return "\(exportCommand); exec \"${SHELL:-/bin/zsh}\" -lc \"\(escapedStartupCommand)\""
+        // Wrap in /bin/sh via exec so the command works regardless of whether the
+        // user's remote login shell is fish, bash, zsh, or any other POSIX shell.
+        // Fish does not understand `export` or `${VAR:-default}` syntax, but /bin/sh
+        // (POSIX) handles both. The outer "..." string is escaped for fish double-quoted
+        // context so fish passes it correctly to sh -c.
+        return "exec /bin/sh -c \"\(innerCommand.escapedForFishDoubleQuotedString)\""
     }
 
     var workspaceScopeFingerprint: String {
@@ -226,6 +235,14 @@ private extension String {
             .replacingOccurrences(of: "\"", with: "\\\"")
             .replacingOccurrences(of: "$", with: "\\$")
             .replacingOccurrences(of: "`", with: "\\`")
+    }
+
+    /// Escapes the string for use inside a fish double-quoted ("...") string.
+    /// Fish interprets `\\` as `\`, `\"` as `"`, and `\$` as a literal `$`.
+    var escapedForFishDoubleQuotedString: String {
+        replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
     }
 
     var containsControlCharacter: Bool {

--- a/Tests/HermesDesktopTests/ConnectionProfileTests.swift
+++ b/Tests/HermesDesktopTests/ConnectionProfileTests.swift
@@ -24,7 +24,7 @@ struct ConnectionProfileTests {
         #expect(profile.remotePath(for: .memory) == "~/.hermes/memories/MEMORY.md")
         #expect(
             profile.remoteShellBootstrapCommand ==
-                "export HERMES_HOME=\"$HOME/.hermes\"; exec \"${SHELL:-/bin/zsh}\" -l"
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -l\""
         )
         #expect(profile.displayDestination == "alice@hermes-home")
         #expect(profile.resolvedPort == nil)
@@ -50,7 +50,7 @@ struct ConnectionProfileTests {
         #expect(profileScoped.remoteKanbanDatabasePath == "~/.hermes/kanban.db")
         #expect(
             profileScoped.remoteShellBootstrapCommand ==
-                "export HERMES_HOME=\"$HOME/.hermes/profiles/researcher\"; exec \"${SHELL:-/bin/zsh}\" -l"
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes/profiles/researcher\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -l\""
         )
         #expect(base.workspaceScopeFingerprint != profileScoped.workspaceScopeFingerprint)
         #expect(base.hostConnectionFingerprint == profileScoped.hostConnectionFingerprint)
@@ -68,7 +68,7 @@ struct ConnectionProfileTests {
 
         #expect(
             profile.remoteShellBootstrapCommand ==
-                "export HERMES_HOME=\"$HOME/.hermes/profiles/research\\\"lab\"; exec \"${SHELL:-/bin/zsh}\" -l"
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes/profiles/research\\\\\\\"lab\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -l\""
         )
     }
 
@@ -83,7 +83,7 @@ struct ConnectionProfileTests {
 
         #expect(
             profile.remoteShellBootstrapCommand ==
-                "export HERMES_HOME=\"$HOME/.hermes/profiles/research\\$HOME\\`whoami\\`\"; exec \"${SHELL:-/bin/zsh}\" -l"
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes/profiles/research\\\\\\$HOME\\\\`whoami\\\\`\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -l\""
         )
     }
 
@@ -136,7 +136,7 @@ struct ConnectionProfileTests {
 
         #expect(
             profile.remoteShellBootstrapCommand(startupCommandLine: "hermes --profile researcher --resume 'debug session'\\''s final turn'") ==
-                "export HERMES_HOME=\"$HOME/.hermes/profiles/researcher\"; exec \"${SHELL:-/bin/zsh}\" -lc \"hermes --profile researcher --resume 'debug session'\\\\''s final turn'\""
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes/profiles/researcher\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -lc \\\"hermes --profile researcher --resume 'debug session'\\\\\\\\''s final turn'\\\"\""
         )
     }
 
@@ -149,7 +149,7 @@ struct ConnectionProfileTests {
 
         #expect(
             profile.remoteShellBootstrapCommand(startupCommandLine: "printf \"$HOME `whoami`\"") ==
-                "export HERMES_HOME=\"$HOME/.hermes\"; exec \"${SHELL:-/bin/zsh}\" -lc \"printf \\\"\\$HOME \\`whoami\\`\\\"\""
+                "exec /bin/sh -c \"export HERMES_HOME=\\\"\\$HOME/.hermes\\\"; exec \\\"\\${SHELL:-/bin/zsh}\\\" -lc \\\"printf \\\\\\\"\\\\\\$HOME \\\\`whoami\\\\`\\\\\\\"\\\"\""
         )
     }
 


### PR DESCRIPTION
Fish shell does not understand export or default syntax used in the remote shell bootstrap command. Wrap the entire command in exec /bin/sh -c with fish-compatible double-quote escaping so it works regardless of whether the user's remote login shell is fish, bash, zsh, or any other POSIX shell.

Adds escapedForFishDoubleQuotedString utility that escapes backslash, double quote, and dollar sign for use inside fish double-quoted strings.

Fixes #27