### PR TITLE
Fix empty host selection state

### DIFF
--- a/Sources/HermesDesktop/App/AppState.swift
+++ b/Sources/HermesDesktop/App/AppState.swift
@@ -159,9 +159,26 @@ final class AppState: ObservableObject {
             }
             .store(in: &cancellables)
 
-        self.activeConnectionID = connectionStore.lastConnectionID
+        let initialConnectionID = Self.initialActiveConnectionID(from: connectionStore)
+        self.activeConnectionID = initialConnectionID
+        if connectionStore.lastConnectionID != initialConnectionID {
+            connectionStore.lastConnectionID = initialConnectionID
+        }
 
         selectedSection = .connections
+    }
+
+    private static func initialActiveConnectionID(from connectionStore: ConnectionStore) -> UUID? {
+        if let lastConnectionID = connectionStore.lastConnectionID,
+           connectionStore.connections.contains(where: { $0.id == lastConnectionID }) {
+            return lastConnectionID
+        }
+
+        return connectionStore.connections.max { lhs, rhs in
+            let lhsDate = lhs.lastConnectedAt ?? lhs.updatedAt
+            let rhsDate = rhs.lastConnectedAt ?? rhs.updatedAt
+            return lhsDate < rhsDate
+        }?.id
     }
 
     var activeConnection: ConnectionProfile? {
@@ -475,6 +492,7 @@ final class AppState: ObservableObject {
         let previous = connectionStore.connections.first(where: { $0.id == normalized.id })
         let isActiveConnection = activeConnectionID == normalized.id
         let isChangingWorkspaceScope = previous?.workspaceScopeFingerprint != normalized.workspaceScopeFingerprint
+        let shouldActivateSavedConnection = activeConnection == nil
 
         if isActiveConnection && isChangingWorkspaceScope && hasUnsavedFileChanges {
             activeAlert = AppAlert(
@@ -485,6 +503,15 @@ final class AppState: ObservableObject {
         }
 
         connectionStore.upsert(normalized)
+
+        if shouldActivateSavedConnection {
+            resetWorkspaceStateForConnectionChange()
+            activeConnectionID = normalized.id
+            connectionStore.lastConnectionID = normalized.id
+            selectedSection = .connections
+            setStatusMessage(L10n.string("Host saved: %@", normalized.label))
+            return
+        }
 
         guard isActiveConnection else { return }
         guard isChangingWorkspaceScope else { return }

--- a/Sources/HermesDesktop/Resources/en.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/en.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "Show full output" = "Show full output";
 "Render the full tool output on demand" = "Render the full tool output on demand";
 "Connecting to %@…" = "Connecting to %@…";
+"Host saved: %@" = "Host saved: %@";
 "Refreshing %@…" = "Refreshing %@…";
 "Switching to %@…" = "Switching to %@…";
 "Testing %@…" = "Testing %@…";

--- a/Sources/HermesDesktop/Resources/ru.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/ru.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "Show full output" = "Показать полный вывод";
 "Render the full tool output on demand" = "Показать полный вывод инструмента по запросу";
 "Connecting to %@…" = "Подключение к %@…";
+"Host saved: %@" = "Хост сохранён: %@";
 "Refreshing %@…" = "Обновление %@…";
 "Switching to %@…" = "Переключение на %@…";
 "Testing %@…" = "Проверка %@…";

--- a/Sources/HermesDesktop/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/zh-Hans.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "Show full output" = "显示完整输出";
 "Render the full tool output on demand" = "按需显示完整工具输出";
 "Connecting to %@…" = "正在连接 %@…";
+"Host saved: %@" = "已保存主机：%@";
 "Refreshing %@…" = "正在刷新 %@…";
 "Switching to %@…" = "正在切换到 %@…";
 "Testing %@…" = "正在测试 %@…";

--- a/Tests/HermesDesktopTests/AppStateConnectionTests.swift
+++ b/Tests/HermesDesktopTests/AppStateConnectionTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import HermesDesktop
+
+@MainActor
+struct AppStateConnectionTests {
+    @Test
+    func savingHostWithoutActiveConnectionSelectsAndPersistsIt() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = makeTestAppPaths(root: root)
+        let appState = AppState(paths: paths)
+
+        appState.saveConnection(
+            ConnectionProfile(
+                label: "Studio Mac",
+                sshHost: "studio.local",
+                sshUser: "alex"
+            )
+        )
+
+        let savedConnection = try #require(appState.connectionStore.connections.first)
+        #expect(appState.activeConnectionID == savedConnection.id)
+        #expect(appState.connectionStore.lastConnectionID == savedConnection.id)
+        #expect(appState.activeConnection?.label == "Studio Mac")
+
+        let reloadedStore = ConnectionStore(paths: paths)
+        #expect(reloadedStore.lastConnectionID == savedConnection.id)
+    }
+
+    @Test
+    func savingAdditionalHostDoesNotSwitchActiveConnection() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appState = AppState(paths: makeTestAppPaths(root: root))
+        let firstConnection = ConnectionProfile(
+            label: "Studio Mac",
+            sshHost: "studio.local",
+            sshUser: "alex"
+        )
+        let secondConnection = ConnectionProfile(
+            label: "Prod VPS",
+            sshHost: "203.0.113.10",
+            sshUser: "deploy"
+        )
+
+        appState.saveConnection(firstConnection)
+        let activeConnectionID = try #require(appState.activeConnectionID)
+
+        appState.saveConnection(secondConnection)
+
+        #expect(appState.activeConnectionID == activeConnectionID)
+        #expect(appState.connectionStore.lastConnectionID == activeConnectionID)
+        #expect(appState.connectionStore.connections.count == 2)
+    }
+
+    @Test
+    func startupSelectsSavedHostWhenLastConnectionPreferenceIsMissing() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = makeTestAppPaths(root: root)
+        let store = ConnectionStore(paths: paths)
+        let olderConnection = ConnectionProfile(
+            label: "Older Host",
+            sshHost: "older.local",
+            lastConnectedAt: Date(timeIntervalSince1970: 100)
+        )
+        let newerConnection = ConnectionProfile(
+            label: "Newer Host",
+            sshHost: "newer.local",
+            lastConnectedAt: Date(timeIntervalSince1970: 200)
+        )
+        store.upsert(olderConnection)
+        store.upsert(newerConnection)
+        #expect(store.lastConnectionID == nil)
+
+        let appState = AppState(paths: paths)
+
+        #expect(appState.activeConnectionID == newerConnection.id)
+        #expect(appState.connectionStore.lastConnectionID == newerConnection.id)
+    }
+
+    @Test
+    func startupIgnoresStaleLastConnectionPreference() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = makeTestAppPaths(root: root)
+        let store = ConnectionStore(paths: paths)
+        let savedConnection = ConnectionProfile(
+            label: "Studio Mac",
+            sshHost: "studio.local"
+        )
+        store.upsert(savedConnection)
+        store.lastConnectionID = UUID()
+
+        let appState = AppState(paths: paths)
+
+        #expect(appState.activeConnectionID == savedConnection.id)
+        #expect(appState.connectionStore.lastConnectionID == savedConnection.id)
+    }
+}


### PR DESCRIPTION
## Summary

  Fixes an empty-state bug where saving a host persists it locally but leaves Hermes Desktop without an active host selection.

  ## Root Cause

  `AppState.saveConnection(_:)` saved the profile but did not promote it to `activeConnectionID` or persist it as `lastConnectionID` when the app had no active host.

  On launch, `AppState` also trusted `lastConnectionID` directly, so a missing or stale preference could strand valid saved hosts in `connections.json`.

  ## Changes

  - Select and persist the saved host when saving from a no-active-host state.
  - Recover at startup from missing or stale `lastConnectionID` by selecting the most recently connected/updated saved host.
  - Add regression tests for first-host save, adding additional hosts without switching, missing last-connection preference, and stale last-connection preference.
  - Add localization for the new host-saved status message.

  ## Validation

  - `./scripts/run-tests.sh` passed with 116 tests.


Co-authored by Codex