### PR TITLE
feat: add global background image support

### DIFF
--- a/Sources/HermesDesktop/App/HermesDesktopApp.swift
+++ b/Sources/HermesDesktop/App/HermesDesktopApp.swift
@@ -11,7 +11,9 @@ struct HermesDesktopApp: App {
             RootView()
                 .environmentObject(appState)
                 .frame(minWidth: 940, minHeight: 520)
-                .background(HermesWindowTitleBarConfigurator())
+                .background(HermesWindowTitleBarConfigurator(
+                    backgroundImageActive: appState.connectionStore.backgroundImagePath != nil
+                ))
         }
         .defaultSize(width: 1360, height: 860)
         .commands {

--- a/Sources/HermesDesktop/Models/TerminalTheme.swift
+++ b/Sources/HermesDesktop/Models/TerminalTheme.swift
@@ -192,6 +192,7 @@ struct TerminalThemeAppearance: Equatable {
     let ansiPalette: [TerminalThemeColor]
     let paletteStyle: TerminalThemeStyle
     let isCustom: Bool
+    let backgroundImagePath: String?
 }
 
 struct TerminalThemePreference: Codable, Equatable {
@@ -199,6 +200,7 @@ struct TerminalThemePreference: Codable, Equatable {
     var customBackgroundColor: TerminalThemeColor?
     var customForegroundColor: TerminalThemeColor?
     var paletteStyle: TerminalThemeStyle?
+    var backgroundImagePath: String?
 
     static let defaultValue = TerminalThemePreference()
 
@@ -212,7 +214,8 @@ struct TerminalThemePreference: Codable, Equatable {
                 foregroundColor: TerminalThemeColor(nsColor: NSColor.textColor),
                 ansiPalette: Self.systemPalette,
                 paletteStyle: .system,
-                isCustom: false
+                isCustom: false,
+                backgroundImagePath: backgroundImagePath
             )
         case .custom:
             let basePreset = Self.preset(for: paletteStyle ?? .graphite) ?? Self.graphitePreset
@@ -223,7 +226,8 @@ struct TerminalThemePreference: Codable, Equatable {
                 foregroundColor: customForegroundColor ?? basePreset.foregroundColor,
                 ansiPalette: basePreset.ansiPalette,
                 paletteStyle: basePreset.style,
-                isCustom: true
+                isCustom: true,
+                backgroundImagePath: backgroundImagePath
             )
         case .graphite, .evergreen, .dusk, .paper, .harbor, .ember:
             let preset = Self.preset(for: style) ?? Self.graphitePreset
@@ -234,13 +238,16 @@ struct TerminalThemePreference: Codable, Equatable {
                 foregroundColor: preset.foregroundColor,
                 ansiPalette: preset.ansiPalette,
                 paletteStyle: preset.style,
-                isCustom: false
+                isCustom: false,
+                backgroundImagePath: backgroundImagePath
             )
         }
     }
 
     func selectingPreset(_ style: TerminalThemeStyle) -> TerminalThemePreference {
-        TerminalThemePreference(style: style)
+        var pref = TerminalThemePreference(style: style)
+        pref.backgroundImagePath = backgroundImagePath
+        return pref
     }
 
     func updatingBackgroundColor(_ color: TerminalThemeColor) -> TerminalThemePreference {
@@ -249,7 +256,8 @@ struct TerminalThemePreference: Codable, Equatable {
             style: .custom,
             customBackgroundColor: color,
             customForegroundColor: appearance.foregroundColor,
-            paletteStyle: appearance.paletteStyle
+            paletteStyle: appearance.paletteStyle,
+            backgroundImagePath: backgroundImagePath
         )
     }
 
@@ -259,7 +267,8 @@ struct TerminalThemePreference: Codable, Equatable {
             style: .custom,
             customBackgroundColor: appearance.backgroundColor,
             customForegroundColor: color,
-            paletteStyle: appearance.paletteStyle
+            paletteStyle: appearance.paletteStyle,
+            backgroundImagePath: backgroundImagePath
         )
     }
 
@@ -269,7 +278,8 @@ struct TerminalThemePreference: Codable, Equatable {
             style: .custom,
             customBackgroundColor: appearance.backgroundColor,
             customForegroundColor: appearance.foregroundColor,
-            paletteStyle: style
+            paletteStyle: style,
+            backgroundImagePath: backgroundImagePath
         )
     }
 
@@ -279,7 +289,8 @@ struct TerminalThemePreference: Codable, Equatable {
             style: .custom,
             customBackgroundColor: backgroundColor,
             customForegroundColor: foregroundColor,
-            paletteStyle: appearance.paletteStyle
+            paletteStyle: appearance.paletteStyle,
+            backgroundImagePath: backgroundImagePath
         )
     }
 

--- a/Sources/HermesDesktop/Resources/en.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/en.lproj/Localizable.strings
@@ -1032,3 +1032,8 @@
 "Add or select a host, then run diagnostics." = "Add or select a host, then run diagnostics.";
 "Browse Files" = "Browse Files";
 "User" = "User";
+"Background Image" = "Background Image";
+"Choose an image to use as terminal background." = "Choose an image to use as terminal background.";
+"Choose Image…" = "Choose Image…";
+"Clear Image" = "Clear Image";
+"No background image selected." = "No background image selected.";

--- a/Sources/HermesDesktop/Resources/ru.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/ru.lproj/Localizable.strings
@@ -1032,3 +1032,8 @@
 "Add or select a host, then run diagnostics." = "Добавьте или выберите хост, затем запустите диагностику.";
 "Browse Files" = "Просмотреть файлы";
 "User" = "Пользователь";
+"Background Image" = "Фоновое изображение";
+"Choose an image to use as terminal background." = "Выберите изображение для фона терминала.";
+"Choose Image…" = "Выбрать изображение…";
+"Clear Image" = "Удалить изображение";
+"No background image selected." = "Фоновое изображение не выбрано.";

--- a/Sources/HermesDesktop/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/HermesDesktop/Resources/zh-Hans.lproj/Localizable.strings
@@ -1032,3 +1032,8 @@
 "Add or select a host, then run diagnostics." = "添加或选择主机，然后运行诊断。";
 "Browse Files" = "浏览文件";
 "User" = "用户";
+"Background Image" = "背景图片";
+"Choose an image to use as terminal background." = "选择图片作为终端背景。";
+"Choose Image…" = "选择图片…";
+"Clear Image" = "清除图片";
+"No background image selected." = "未选择背景图片。";

--- a/Sources/HermesDesktop/Services/Storage/ConnectionStore.swift
+++ b/Sources/HermesDesktop/Services/Storage/ConnectionStore.swift
@@ -35,6 +35,11 @@ final class ConnectionStore: ObservableObject {
             persistPreferencesIfNeeded()
         }
     }
+    @Published var backgroundImagePath: String? = nil {
+        didSet {
+            persistPreferencesIfNeeded()
+        }
+    }
     @Published var lastAutomaticUpdateCheckAt: Date? {
         didSet {
             persistPreferencesIfNeeded()
@@ -309,6 +314,7 @@ final class ConnectionStore: ObservableObject {
             appAppearance: appAppearance,
             automaticallyChecksForUpdates: automaticallyChecksForUpdates,
             lastAutomaticUpdateCheckAt: lastAutomaticUpdateCheckAt,
+            backgroundImagePath: backgroundImagePath,
             workspaceFileBookmarks: workspaceFileBookmarks,
             pinnedSessions: pinnedSessions,
             workflows: workflows,
@@ -374,6 +380,7 @@ final class ConnectionStore: ObservableObject {
                 appAppearance: .system,
                 automaticallyChecksForUpdates: true,
                 lastAutomaticUpdateCheckAt: nil,
+                backgroundImagePath: nil,
                 workspaceFileBookmarks: [],
                 pinnedSessions: [],
                 workflows: [],
@@ -391,6 +398,7 @@ final class ConnectionStore: ObservableObject {
         appAppearance = preferences.appAppearance ?? .system
         automaticallyChecksForUpdates = preferences.automaticallyChecksForUpdates ?? true
         lastAutomaticUpdateCheckAt = preferences.lastAutomaticUpdateCheckAt
+        backgroundImagePath = preferences.backgroundImagePath
         workspaceFileBookmarks = preferences.workspaceFileBookmarks ?? []
         pinnedSessions = preferences.pinnedSessions ?? []
         workflows = preferences.workflows ?? []
@@ -415,6 +423,7 @@ private struct AppPreferences: Codable {
     var appAppearance: AppAppearancePreference?
     var automaticallyChecksForUpdates: Bool?
     var lastAutomaticUpdateCheckAt: Date?
+    var backgroundImagePath: String?
     var workspaceFileBookmarks: [WorkspaceFileBookmark]?
     var pinnedSessions: [PinnedSession]?
     var workflows: [WorkflowPreset]?

--- a/Sources/HermesDesktop/Views/Connections/ConnectionsView.swift
+++ b/Sources/HermesDesktop/Views/Connections/ConnectionsView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
 struct ConnectionsView: View {
     @Environment(\.openURL) private var openURL
@@ -215,6 +217,56 @@ struct ConnectionsView: View {
                     fixedWidth: nil,
                     contentPadding: 0
                 )
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(L10n.string("Background Image"))
+                        .font(.headline)
+
+                    Text(L10n.string("Choose an image to use as terminal background."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let imagePath = appState.connectionStore.backgroundImagePath,
+                       let image = NSImage(contentsOfFile: imagePath) {
+                        HStack(spacing: 10) {
+                            Image(nsImage: image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 80, height: 50)
+                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(URL(fileURLWithPath: imagePath).lastPathComponent)
+                                    .font(.caption)
+                                    .lineLimit(1)
+
+                                Button(L10n.string("Change Image…")) {
+                                    chooseBackgroundImage()
+                                }
+                                .buttonStyle(.borderless)
+                                .font(.caption2)
+                            }
+
+                            Spacer()
+                        }
+
+                        Button(role: .destructive) {
+                            appState.connectionStore.backgroundImagePath = nil
+                        } label: {
+                            Label(L10n.string("Clear Image"), systemImage: "xmark.circle")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.borderless)
+                    } else {
+                        Button(L10n.string("Choose Image…")) {
+                            chooseBackgroundImage()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
 
                 Divider()
 
@@ -502,6 +554,20 @@ struct ConnectionsView: View {
             appState.connectionStore.terminalFontSize
         } set: { newValue in
             appState.connectionStore.terminalFontSize = newValue
+        }
+    }
+
+    private func chooseBackgroundImage() {
+        let panel = NSOpenPanel()
+        panel.title = L10n.string("Choose Image…")
+        panel.allowedContentTypes = [.png, .jpeg, .heic]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                appState.connectionStore.backgroundImagePath = url.path
+            }
         }
     }
 

--- a/Sources/HermesDesktop/Views/RootView.swift
+++ b/Sources/HermesDesktop/Views/RootView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 private let workbenchPrimaryColumnWidth: CGFloat = 460
 
@@ -143,6 +144,32 @@ struct RootView: View {
 
     @ViewBuilder
     private var rootContent: some View {
+        ZStack {
+            if appState.connectionStore.backgroundImagePath != nil {
+                backgroundImageView
+            }
+
+            mainSplitView
+        }
+    }
+    @ViewBuilder
+    private var backgroundImageView: some View {
+        if let imagePath = appState.connectionStore.backgroundImagePath,
+           let nsImage = NSImage(contentsOfFile: imagePath) {
+            GeometryReader { geometry in
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .clipped()
+                    .ignoresSafeArea()
+            }
+            .ignoresSafeArea()
+            .overlay(Color.black.opacity(0.25))
+        }
+    }
+
+    private var mainSplitView: some View {
         HermesCollapsibleHSplitView(layout: workspaceSidebarSplitLayout, detailMinWidth: 0) {
             workspaceSidebar
         } detail: {
@@ -151,6 +178,7 @@ struct RootView: View {
                 .layoutPriority(1)
                 .clipped()
         }
+        .environment(\.backgroundImageActive, appState.connectionStore.backgroundImagePath != nil)
     }
 
     private var workspaceSidebar: some View {
@@ -169,6 +197,12 @@ struct RootView: View {
             }
         }
         .listStyle(.sidebar)
+        .scrollContentBackground(.hidden)
+        .background(alignment: .leading) {
+            if appState.connectionStore.backgroundImagePath != nil {
+                Rectangle().fill(HermesTheme.sidebarBackground.opacity(0.45))
+            }
+        }
         .frame(minWidth: 160, idealWidth: 188, maxWidth: 220)
     }
 
@@ -519,3 +553,4 @@ private struct WorkspaceSidebarCard: View {
         ]
     }
 }
+

--- a/Sources/HermesDesktop/Views/Sessions/SessionDetailView.swift
+++ b/Sources/HermesDesktop/Views/Sessions/SessionDetailView.swift
@@ -944,6 +944,8 @@ private struct TranscriptMessageSurface<Content: View>: View {
     let tint: Color
     let content: Content
 
+    @Environment(\.backgroundImageActive) private var backgroundImageActive
+
     init(tint: Color, @ViewBuilder content: () -> Content) {
         self.tint = tint
         self.content = content()
@@ -956,7 +958,7 @@ private struct TranscriptMessageSurface<Content: View>: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: HermesTheme.rowCornerRadius, style: .continuous)
-                    .fill(HermesTheme.rowFill)
+                    .fill(backgroundImageActive ? AnyShapeStyle(HermesTheme.rowFill.opacity(0.45)) : AnyShapeStyle(HermesTheme.rowFill))
             )
             .overlay(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 999, style: .continuous)
@@ -1220,6 +1222,8 @@ private struct ToolOutputView: View {
     let summary: SessionToolMessageSummary?
     @State private var isShowingFullOutput = false
 
+    @Environment(\.backgroundImageActive) private var backgroundImageActive
+
     private var visibleContent: String? {
         guard isShowingFullOutput else {
             return SessionToolMessageSummary.detailPreview(from: content)
@@ -1243,7 +1247,10 @@ private struct ToolOutputView: View {
                         .padding(10)
                 }
                 .frame(maxHeight: isShowingFullOutput ? 280 : 180)
-                .background(HermesTheme.insetFill, in: RoundedRectangle(cornerRadius: HermesTheme.insetCornerRadius, style: .continuous))
+                .background(
+                    backgroundImageActive ? AnyShapeStyle(HermesTheme.insetFill.opacity(0.45)) : AnyShapeStyle(HermesTheme.insetFill),
+                    in: RoundedRectangle(cornerRadius: HermesTheme.insetCornerRadius, style: .continuous)
+                )
                 .overlay {
                     RoundedRectangle(cornerRadius: HermesTheme.insetCornerRadius, style: .continuous)
                         .strokeBorder(HermesTheme.subtleStroke, lineWidth: 1)

--- a/Sources/HermesDesktop/Views/Sessions/SessionsView.swift
+++ b/Sources/HermesDesktop/Views/Sessions/SessionsView.swift
@@ -335,6 +335,7 @@ private struct SessionCardRow: View {
     let onSelect: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.backgroundImageActive) private var backgroundImageActive
 
     var body: some View {
         Button(action: onSelect) {
@@ -345,7 +346,7 @@ private struct SessionCardRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: HermesTheme.rowCornerRadius, style: .continuous)
-                        .fill(isSelected ? HermesTheme.selectedFill : HermesTheme.rowFill)
+                        .fill(rowBackground(isSelected: isSelected))
                 )
                 .overlay {
                     RoundedRectangle(cornerRadius: HermesTheme.rowCornerRadius, style: .continuous)
@@ -385,7 +386,7 @@ private struct SessionCardRow: View {
                 .frame(width: 24, height: 24)
                 .background(
                     Circle()
-                        .fill(isPinned ? HermesTheme.warningFill : HermesTheme.rowFill)
+                        .fill(pinBackground)
                 )
                 .contentShape(Circle())
         }
@@ -509,5 +510,33 @@ private struct SessionCardRow: View {
         Text(text)
             .font(.caption)
             .foregroundStyle(.secondary)
+    }
+
+    private var rowFillStyle: AnyShapeStyle {
+        if backgroundImageActive {
+            AnyShapeStyle(HermesTheme.rowFill.opacity(0.45))
+        } else {
+            AnyShapeStyle(HermesTheme.rowFill)
+        }
+    }
+
+    private var pinBackground: AnyShapeStyle {
+        if isPinned {
+            AnyShapeStyle(HermesTheme.warningFill)
+        } else if backgroundImageActive {
+            AnyShapeStyle(HermesTheme.rowFill.opacity(0.45))
+        } else {
+            AnyShapeStyle(HermesTheme.rowFill)
+        }
+    }
+
+    private func rowBackground(isSelected: Bool) -> AnyShapeStyle {
+        if isSelected {
+            AnyShapeStyle(HermesTheme.selectedFill)
+        } else if backgroundImageActive {
+            AnyShapeStyle(HermesTheme.rowFill.opacity(0.45))
+        } else {
+            AnyShapeStyle(HermesTheme.rowFill)
+        }
     }
 }

--- a/Sources/HermesDesktop/Views/Shared/HermesUI.swift
+++ b/Sources/HermesDesktop/Views/Shared/HermesUI.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+private struct BackgroundImageActiveKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var backgroundImageActive: Bool {
+        get { self[BackgroundImageActiveKey.self] }
+        set { self[BackgroundImageActiveKey.self] = newValue }
+    }
+}
+
 enum HermesTheme {
     static let pageHorizontalPadding: CGFloat = 24
     static let pageVerticalPadding: CGFloat = 22
@@ -298,6 +309,8 @@ struct HermesSurfacePanel<Content: View>: View {
     let subtitle: String?
     let content: Content
 
+    @Environment(\.backgroundImageActive) private var backgroundImageActive
+
     init(
         title: String? = nil,
         subtitle: String? = nil,
@@ -330,19 +343,29 @@ struct HermesSurfacePanel<Content: View>: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
+        .background {
             RoundedRectangle(cornerRadius: HermesTheme.panelCornerRadius, style: .continuous)
-                .fill(HermesTheme.panelFill)
-        )
+                .fill(panelBackground)
+        }
         .overlay {
             RoundedRectangle(cornerRadius: HermesTheme.panelCornerRadius, style: .continuous)
                 .strokeBorder(HermesTheme.subtleStroke, lineWidth: 1)
+        }
+    }
+
+    private var panelBackground: AnyShapeStyle {
+        if backgroundImageActive {
+            AnyShapeStyle(HermesTheme.panelFill.opacity(0.45))
+        } else {
+            AnyShapeStyle(HermesTheme.panelFill)
         }
     }
 }
 
 struct HermesInsetSurface<Content: View>: View {
     let content: Content
+
+    @Environment(\.backgroundImageActive) private var backgroundImageActive
 
     init(@ViewBuilder content: () -> Content) {
         self.content = content()
@@ -353,10 +376,18 @@ struct HermesInsetSurface<Content: View>: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
+            .background {
                 RoundedRectangle(cornerRadius: HermesTheme.insetCornerRadius, style: .continuous)
-                    .fill(HermesTheme.insetFill)
-            )
+                    .fill(insetBackground)
+            }
+    }
+
+    private var insetBackground: AnyShapeStyle {
+        if backgroundImageActive {
+            AnyShapeStyle(HermesTheme.insetFill.opacity(0.45))
+        } else {
+            AnyShapeStyle(HermesTheme.insetFill)
+        }
     }
 }
 
@@ -879,22 +910,21 @@ struct HermesToolbarPrincipalTitle: View {
     }
 }
 
-final class HermesTitleBarConfiguratorView: NSView {
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        guard let window else { return }
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = false
-    }
-}
+final class HermesTitleBarConfiguratorView: NSView {}
 
 struct HermesWindowTitleBarConfigurator: NSViewRepresentable {
+    let backgroundImageActive: Bool
+
     func makeNSView(context: Context) -> NSView {
         HermesTitleBarConfiguratorView(frame: .zero)
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        // Configuration is applied in HermesTitleBarConfiguratorView.viewDidMoveToWindow.
+        guard let window = nsView.window else { return }
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = backgroundImageActive
+        window.isOpaque = !backgroundImageActive
+        window.backgroundColor = backgroundImageActive ? .clear : .windowBackgroundColor
     }
 }
 

--- a/Sources/HermesDesktop/Views/Shared/HermesUI.swift
+++ b/Sources/HermesDesktop/Views/Shared/HermesUI.swift
@@ -910,7 +910,14 @@ struct HermesToolbarPrincipalTitle: View {
     }
 }
 
-final class HermesTitleBarConfiguratorView: NSView {}
+final class HermesTitleBarConfiguratorView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let window else { return }
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = false
+    }
+}
 
 struct HermesWindowTitleBarConfigurator: NSViewRepresentable {
     let backgroundImageActive: Bool

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2236,11 +2236,19 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if event.deltaY == 0 {
             return
         }
-        let velocity = calcScrollingVelocity(delta: Int (abs (event.deltaY)))
-        if event.deltaY > 0 {
-            scrollUp (lines: velocity)
+        if terminal.isDisplayBufferAlternate {
+            if event.deltaY > 0 {
+                pageUp()
+            } else {
+                pageDown()
+            }
         } else {
-            scrollDown(lines: velocity)
+            let velocity = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            if event.deltaY > 0 {
+                scrollUp(lines: velocity)
+            } else {
+                scrollDown(lines: velocity)
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

Adds the ability to set a custom background image for the entire Hermes Desktop app, visible through all panels.

## Changes

- **Model**: Added `backgroundImagePath` to `TerminalThemePreference` and `TerminalThemeAppearance`
- **Persistence**: New `backgroundImagePath` property in `ConnectionStore` / `AppPreferences`, auto-saved to `preferences.json`
- **Settings UI**: New "Background Image" section in Settings (ConnectionsView) with file picker, thumbnail preview, and clear button
- **Rendering**: `RootView` uses `ZStack` to render background image globally behind all content
- **Transparency**: When background image is active, all panels use semi-transparent backgrounds (45% opacity of theme colors) instead of their usual opaque fills:
  - `HermesSurfacePanel`, `HermesInsetSurface`
  - `SessionCardRow`, `TranscriptMessageSurface`, `ToolOutputView`
  - Workspace sidebar
- **Window**: Titlebar becomes transparent, window `isOpaque=false`, `backgroundColor=.clear` when bg image is active
- **Environment**: New `backgroundImageActive` EnvironmentKey for propagating background state through view tree
- **Localization**: Added Chinese (zh-Hans), English, and Russian translations