### PR TITLE
fix: forward scroll wheel events to PTY in alternate screen mode

### DIFF
--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -2236,11 +2236,19 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if event.deltaY == 0 {
             return
         }
-        let velocity = calcScrollingVelocity(delta: Int (abs (event.deltaY)))
-        if event.deltaY > 0 {
-            scrollUp (lines: velocity)
+        if terminal.isDisplayBufferAlternate {
+            if event.deltaY > 0 {
+                pageUp()
+            } else {
+                pageDown()
+            }
         } else {
-            scrollDown(lines: velocity)
+            let velocity = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            if event.deltaY > 0 {
+                scrollUp(lines: velocity)
+            } else {
+                scrollDown(lines: velocity)
+            }
         }
     }
     


### PR DESCRIPTION
## Problem

Chat mode terminal (running `hermes --tui`) could not be scrolled with mouse wheel or trackpad.

## Root Cause

SwiftTerm`MacTerminalView.scrollWheel()` always called `scrollUp()`/`scrollDown()` for internal terminal scrollback, even when the terminal was in alternate screen mode (e.g., TUI running). These internal scroll methods are ineffective in alternate screen mode because the alt buffer has no scrollback lines.

Meanwhile, `pageUp()`/`pageDown()` already had the correct alternate screen handling — they send escape sequences (CSI 5~ / CSI 6~) to the PTY process.

## Fix

Modified `scrollWheel()` to check `terminal.isDisplayBufferAlternate`:
- When in alternate screen mode: call `pageUp()`/`pageDown()` which forward events to PTY
- When in normal mode: use existing `scrollUp()`/`scrollDown()` behavior

## Files Changed

- `Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift` — 1 file, +12/-4 lines