### PR TITLE
docs: add Hermes Tweet desktop context

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ host they already use, without adding another layer to trust.
 Use direct-local mode when Hermes is installed on this Mac. Use SSH mode for a
 Raspberry Pi, another Mac, a VPS, or a remote server.
 
+### Companion X/Twitter context
+
+When a Hermes workflow uses
+[Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) to collect X/Twitter
+account, post, or trend context, Hermes Desktop can keep the follow-up work in
+the same native loop: sessions, workspace files, editable skills, cron jobs,
+Kanban, usage, and terminal remain tied to the selected host and profile.
+
+Hermes Tweet is a third-party Hermes plugin from
+[Xquik](https://xquik.com), maintained by Xquik-dev and not by this repository.
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
 ## How the app is designed
 
 The app runs the same service commands either locally or over SSH. Sessions
@@ -324,7 +337,7 @@ It lets you choose the right one for the job.
 
 - Use `Chat` in `Sessions` when you want the real Hermes TUI embedded in the
   app, already scoped to the active connection and Hermes profile. The Chat
-  view is a hosted `hermes --tui` session — there is no separate Desktop
+  view is a hosted `hermes --tui` session - there is no separate Desktop
   conversation layer in front of it.
 - Use `Transcript` in `Sessions` when you want to inspect persisted history from
   the host without starting or resuming a live TUI.

--- a/Sources/HermesDesktop/Services/UpdateCheckService.swift
+++ b/Sources/HermesDesktop/Services/UpdateCheckService.swift
@@ -59,8 +59,12 @@ struct UpdateCheckService: Sendable {
     }
 
     static func isVersion(_ candidate: String, newerThan current: String) -> Bool {
-        let candidateComponents = numericVersionComponents(from: candidate)
-        let currentComponents = numericVersionComponents(from: current)
+        guard
+            let candidateComponents = numericVersionComponents(from: candidate),
+            let currentComponents = numericVersionComponents(from: current)
+        else {
+            return false
+        }
         let componentCount = max(candidateComponents.count, currentComponents.count)
 
         for index in 0..<componentCount {
@@ -87,10 +91,33 @@ struct UpdateCheckService: Sendable {
         return String(trimmed.dropFirst())
     }
 
-    private static func numericVersionComponents(from value: String) -> [Int] {
-        normalizedDisplayVersion(value)
-            .split { !$0.isNumber }
-            .compactMap { Int($0) }
+    private static func numericVersionComponents(from value: String) -> [Int]? {
+        let version = normalizedDisplayVersion(value)
+        let coreVersion = version.split(
+            whereSeparator: { $0 == "-" || $0 == "+" }
+        ).first ?? ""
+        let components = coreVersion.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+
+        guard !components.isEmpty else {
+            return nil
+        }
+
+        var numbers: [Int] = []
+        for component in components {
+            guard
+                !component.isEmpty,
+                component.allSatisfy(\.isNumber),
+                let number = Int(component)
+            else {
+                return nil
+            }
+            numbers.append(number)
+        }
+
+        return numbers
     }
 }
 

--- a/Tests/HermesDesktopTests/UpdateCheckServiceTests.swift
+++ b/Tests/HermesDesktopTests/UpdateCheckServiceTests.swift
@@ -35,6 +35,14 @@ struct UpdateCheckServiceTests {
         #expect(UpdateCheckService.isVersion("v0.10.0", newerThan: "0.9.9"))
         #expect(!UpdateCheckService.isVersion("v0.6.1", newerThan: "0.6.1"))
         #expect(!UpdateCheckService.isVersion("v0.6.0", newerThan: "0.6.1"))
+        #expect(UpdateCheckService.isVersion("v0.6.2+19", newerThan: "0.6.1"))
+    }
+
+    @Test
+    func ignoresMalformedVersionStrings() {
+        #expect(!UpdateCheckService.isVersion("release-2026.07.20", newerThan: "1.2.0"))
+        #expect(!UpdateCheckService.isVersion("v1..3", newerThan: "1.2.0"))
+        #expect(!UpdateCheckService.isVersion("v1.3.0", newerThan: "current"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a README note for using Hermes Tweet context with Hermes Desktop.
- Tie the note to Desktop surfaces: sessions, files, skills, cron jobs, Kanban, usage, and terminal.
- Identify Hermes Tweet as an Xquik plugin and include the required X Corp independence notice.
- Reject malformed release tags instead of misreading date-like text as a newer app version.
- Add regression coverage for build metadata and malformed version strings.

## Independent repository fix

The update checker previously extracted every digit group from arbitrary tag text. A tag such as release-2026.07.20 could therefore appear newer than the installed app. The repaired parser accepts a numeric dotted core, permits standard prerelease or build suffixes, and safely ignores malformed candidate or current versions.

## Affiliation

I maintain the linked Hermes Tweet project through Xquik-dev.

## Validation

- Swift syntax parsing passed for the changed Swift source and tests with the compatible macOS 15.5 SDK.
- Focused version parser probes passed.
- Git diff checks passed.
- Full SwiftPM execution is delegated to macOS CI because this host has mismatched Command Line Tools package binaries.